### PR TITLE
Energy dashboard: battery + real-time energy/power sensors (v2.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__/
 .pytest_cache/
 /config/
+/dist/
 *.zip
 /.coverage
 /coverage.xml

--- a/README.md
+++ b/README.md
@@ -88,6 +88,58 @@ At the end of this step, an attempt is made to connect to the device and see if
 it returns any data. When succesfully connected, the device will show up in your
 Home Assistant installation.
 
+## Energy dashboard
+
+The integration exposes dedicated battery charge/discharge sensors so the battery
+can be tracked in the Home Assistant Energy dashboard:
+
+- **Battery Charge Power** / **Battery Discharge Power** _(W)_: the instantaneous
+  power flowing into and out of the battery, split by direction.
+- **Battery Charge Energy Total** / **Battery Discharge Energy Total** _(kWh)_:
+  cumulative energy stored into and drawn from the battery. The Delios API only
+  reports instantaneous battery power, so these totals are computed by integrating
+  the power over time and are restored across restarts.
+
+To configure the battery in the Energy dashboard, go to Settings / Dashboards /
+Energy, add a battery system, and select _Battery Charge Energy Total_ as the
+energy going into the battery and _Battery Discharge Energy Total_ as the energy
+coming out of the battery.
+
+### Energy totals (photovoltaic / grid / self-consumption)
+
+The **Photovoltaic / Buyed / Injected / Self Consumed Energy Total** sensors
+_(kWh, `total_increasing`)_ are computed by **integrating the instantaneous power
+over time** (trapezoidal rule, restored across restarts) — the same technique used
+for the battery energy totals.
+
+> **Why not the inverter's own totals?** The Delios `/info/totalizer` endpoint only
+> commits its cumulative counters **once per day, at the inverter's local
+> midnight**, and the inverter clock stays on standard time (it does not follow
+> DST). Fed into the Energy dashboard, a whole day's energy therefore appeared in a
+> single **01:00 bucket** (00:00 in winter) and was attributed to the wrong day.
+> Integrating the live power instead produces correctly time-bucketed, DST-correct
+> energy. These integrated sensors replace the former totalizer-based ones (same
+> entity ids) and start accumulating from 0 on upgrade.
+
+Use _Photovoltaic Energy Total_ as solar production, _Buyed Energy Total_ as grid
+consumption and _Injected Energy Total_ as return to grid in the Energy dashboard.
+
+### Instantaneous power flows
+
+The integration also exposes the matching **instantaneous power** _(W)_ so each
+flow can be tracked live on a normal dashboard (power-flow cards, gauges, history):
+
+- **Photovoltaic Power** — instantaneous PV production (`photovoltaic_power`).
+- **Buyed Power** / **Injected Power** — power drawn from / fed into the grid,
+  split by direction from the single signed grid power reported by the inverter.
+- **Self Consumed Power** — the share of PV production consumed on site rather
+  than exported.
+
+> Sign convention (verified on an IBRIDO DLS unit): `PowerGrid > 0` is power
+> drawn from the grid (buyed), `PowerGrid < 0` is power injected into the grid.
+> If the readings are swapped on your inverter, flip the sign in
+> `custom_components/delios/entity.py`.
+
 ## Next steps
 
 1. This component is mostly unit-tested thanks to the upstream project, but there are a few more to complete.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Home Assistant installation.
 The integration exposes dedicated battery charge/discharge sensors so the battery
 can be tracked in the Home Assistant Energy dashboard:
 
-- **Battery Charge Power** / **Battery Discharge Power** _(W)_: the instantaneous
+- **Battery Charge Power** / **Battery Discharge Power** _(kW)_: the instantaneous
   power flowing into and out of the battery, split by direction.
 - **Battery Charge Energy Total** / **Battery Discharge Energy Total** _(kWh)_:
   cumulative energy stored into and drawn from the battery. The Delios API only
@@ -126,7 +126,7 @@ consumption and _Injected Energy Total_ as return to grid in the Energy dashboar
 
 ### Instantaneous power flows
 
-The integration also exposes the matching **instantaneous power** _(W)_ so each
+The integration also exposes the matching **instantaneous power** _(kW)_ so each
 flow can be tracked live on a normal dashboard (power-flow cards, gauges, history):
 
 - **Photovoltaic Power** — instantaneous PV production (`photovoltaic_power`).

--- a/custom_components/delios/client.py
+++ b/custom_components/delios/client.py
@@ -90,12 +90,6 @@ class DeliosClient:
         if data is not None:
             return ParametersData(data)
 
-    async def totalizer(self) -> TotalizerData | None:
-        """Request totalizer data to Delios Web Server."""
-        data = await self.__request("info/totalizer")
-        if data is not None:
-            return TotalizerData(data)
-
     async def firmware(self) -> FirmwareData | None:
         """Request firmware data to Delios Web Server."""
         data = await self.__request("info/firmware")
@@ -140,7 +134,7 @@ class SensorsData:
     def __init__(self, data: dict) -> None:
         """Initialize sensors data from JSON."""
         self._data = {}
-        if "variables" in data:
+        if "variables" in data and isinstance(data["variables"], list):
             for variable in data["variables"]:
                 self._data[variable["ctrl_name"]] = variable["value"]
 
@@ -167,7 +161,7 @@ class ParametersData:
     def __init__(self, data: dict) -> None:
         """Initialize paramters data from JSON."""
         self._data = {}
-        if "variables" in data:
+        if "variables" in data and isinstance(data["variables"], list):
             for variable in data["variables"]:
                 self._data[variable["ctrl_name"]] = variable["value"]
 
@@ -176,17 +170,6 @@ class ParametersData:
         if name in self._data:
             return float(self._data[name])
         raise InvalidAttribute(name)
-
-
-class TotalizerData:
-    """Totalizer data from Delios Web Server."""
-
-    def __init__(self, data: dict) -> None:
-        """Initialize totalizer data from JSON."""
-        self.photovoltaic = float(data["totalizers"]["TotalEnergyPV"])
-        self.buyed = float(data["totalizers"]["TotalEnergyBuyed"])
-        self.injected = float(data["totalizers"]["TotalEnergyInjected"])
-        self.self_consumed = float(data["totalizers"]["TotalEnergySelfConsumed"])
 
 
 class FirmwareData:

--- a/custom_components/delios/coordinator.py
+++ b/custom_components/delios/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -12,7 +12,11 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    RestoreSensor,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -20,9 +24,10 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util import dt as dt_util
 from homeassistant.util import slugify
 
-from .client import DeliosClient, UnauthorizedClient
+from .client import DeliosClient, InvalidAttribute, UnauthorizedClient
 from .const import DOMAIN, SYSTEM_UPDATE_INTERVAL
 from .entity import SENSORS, SETTINGS, DeliosEntityType, DeliosInverterAttribute
 from .inverter import DeliosInverter
@@ -31,6 +36,12 @@ _LOGGER = logging.getLogger(__name__)
 
 ENTITY_ID_SENSOR_FORMAT = SENSOR_DOMAIN + ".{}_{}"
 ENTITY_ID_BINARY_SENSOR_FORMAT = BINARY_SENSOR_DOMAIN + ".{}_{}"
+
+# Errors raised while evaluating an attribute value when the underlying inverter
+# data is missing or not yet available (e.g. an endpoint returned no variables for
+# this hardware). Such an attribute is treated as "value unavailable" rather than
+# being allowed to crash entity setup or a coordinator update.
+VALUE_UNAVAILABLE_ERRORS = (KeyError, TypeError, ValueError, InvalidAttribute)
 
 
 class DeliosBinarySensor(CoordinatorEntity, BinarySensorEntity):
@@ -59,12 +70,17 @@ class DeliosBinarySensor(CoordinatorEntity, BinarySensorEntity):
             manufacturer="Delios",
             model=inverter.model,
         )
+        self._attr_is_on = None
+        self._internal_attributes = {}
         if self.coordinator.data:
-            self._attr_is_on = self._attribute.value(self.coordinator.data)
-            self._internal_attributes = {
-                attribute: value(self.coordinator.data)
-                for attribute, value in self._attribute.attributes.items()
-            }
+            try:
+                self._attr_is_on = self._attribute.value(self.coordinator.data)
+                self._internal_attributes = {
+                    attribute: value(self.coordinator.data)
+                    for attribute, value in self._attribute.attributes.items()
+                }
+            except VALUE_UNAVAILABLE_ERRORS:
+                pass
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
@@ -83,7 +99,7 @@ class DeliosBinarySensor(CoordinatorEntity, BinarySensorEntity):
                 for attribute, value in self._attribute.attributes.items()
             }
             self.async_write_ha_state()
-        except KeyError:
+        except VALUE_UNAVAILABLE_ERRORS:
             pass
 
 
@@ -117,12 +133,16 @@ class DeliosSensor(CoordinatorEntity, SensorEntity):
             manufacturer="Delios",
             model=inverter.model,
         )
+        self._internal_attributes = {}
         if self.coordinator.data:
-            self._internal_value = self._attribute.value(self.coordinator.data)
-            self._internal_attributes = {
-                attribute: value(self.coordinator.data)
-                for attribute, value in self._attribute.attributes.items()
-            }
+            try:
+                self._internal_value = self._attribute.value(self.coordinator.data)
+                self._internal_attributes = {
+                    attribute: value(self.coordinator.data)
+                    for attribute, value in self._attribute.attributes.items()
+                }
+            except VALUE_UNAVAILABLE_ERRORS:
+                pass
 
     @property
     def native_value(self) -> str | int | None:
@@ -147,8 +167,100 @@ class DeliosSensor(CoordinatorEntity, SensorEntity):
                 for attribute, value in self._attribute.attributes.items()
             }
             self.async_write_ha_state()
-        except KeyError:
+        except VALUE_UNAVAILABLE_ERRORS:
             pass
+
+
+class DeliosIntegrationSensor(CoordinatorEntity, RestoreSensor):
+    """Delios energy sensor computed by integrating an instantaneous power value over time.
+
+    The Delios API only exposes the instantaneous battery power, not cumulative
+    charge/discharge energy. This sensor integrates the power (in watts) returned
+    by the attribute over time to produce a kWh total that can be used in the Home
+    Assistant Energy dashboard. The running total is restored across restarts.
+    """
+
+    def __init__(
+        self, coordinator: DeliosCoordinator, attribute: DeliosInverterAttribute
+    ) -> None:
+        """Initialize integration sensor."""
+
+        super().__init__(coordinator, context=attribute)
+        self._attribute = attribute
+        self._state: float = 0.0
+        self._last_power: float | None = None
+        self._last_update: datetime | None = None
+        inverter = self.coordinator.inverter
+        self.entity_id = ENTITY_ID_SENSOR_FORMAT.format(
+            slugify(inverter.name), attribute.key
+        )
+        self.entity_description = SensorEntityDescription(
+            key=attribute.key,
+            name=attribute.name,
+            state_class=attribute.state_class,
+            device_class=attribute.device_class,
+            native_unit_of_measurement=attribute.unit_of_measurement,
+            suggested_display_precision=attribute.suggested_display_precision,
+        )
+        self._attr_unique_id = f"{inverter.unique_id}-{attribute.key}"
+        self._attr_device_info = DeviceInfo(
+            name=inverter.name,
+            identifiers={(DOMAIN, inverter.unique_id)},
+            manufacturer="Delios",
+            model=inverter.model,
+        )
+
+    @property
+    def native_value(self) -> float:
+        """Return the accumulated energy."""
+
+        return self._state
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last accumulated value and seed the integration baseline."""
+
+        await super().async_added_to_hass()
+        last_data = await self.async_get_last_sensor_data()
+        if last_data is not None and last_data.native_value is not None:
+            try:
+                self._state = float(last_data.native_value)
+            except (TypeError, ValueError):
+                self._state = 0.0
+        self._integrate()
+
+    def _current_power(self) -> float | None:
+        """Return the instantaneous power (in watts) to integrate."""
+
+        try:
+            return self._attribute.value(self.coordinator.data)
+        except VALUE_UNAVAILABLE_ERRORS:
+            return None
+
+    def _integrate(self) -> None:
+        """Accumulate energy using the trapezoidal rule between two power readings."""
+
+        now = dt_util.utcnow()
+        power = self._current_power()
+        if (
+            power is not None
+            and self._last_power is not None
+            and self._last_update is not None
+        ):
+            elapsed = (now - self._last_update).total_seconds()
+            if elapsed > 0:
+                average_power = (power + self._last_power) / 2
+                # W * s -> Wh (/3600) -> kWh (/1000)
+                self._state += average_power * elapsed / 3600 / 1000
+        if power is not None:
+            self._last_power = power
+            self._last_update = now
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+
+        self._integrate()
+        self.async_write_ha_state()
 
 
 class DeliosCoordinator(DataUpdateCoordinator):
@@ -191,9 +303,14 @@ class DeliosCoordinator(DataUpdateCoordinator):
             for entity in self.entities:
                 if entity.type == attribute_type:
                     if entity.type == DeliosEntityType.SENSOR:
+                        sensor = (
+                            DeliosIntegrationSensor(self, entity)
+                            if entity.integration
+                            else DeliosSensor(self, entity)
+                        )
                         self.hass.data[DOMAIN][self._inverter.unique_id][SENSOR_DOMAIN][
                             entity.key
-                        ] = DeliosSensor(self, entity)
+                        ] = sensor
                         entities.append(
                             self.hass.data[DOMAIN][self._inverter.unique_id][
                                 SENSOR_DOMAIN
@@ -262,7 +379,6 @@ class DeliosSystemCoordinator(DeliosCoordinator):
         """Fetch data from API endpoint."""
         data: dict[str, Any] = {
             "status": None,
-            "totalizer": None,
             "alarms": None,
         }
         # status
@@ -270,11 +386,6 @@ class DeliosSystemCoordinator(DeliosCoordinator):
             data["status"] = await self._client.status()
         except UnauthorizedClient:
             _LOGGER.error("Unable to retreive status data")
-        # totalizer
-        try:
-            data["totalizer"] = await self._client.totalizer()
-        except UnauthorizedClient:
-            _LOGGER.error("Unable to retreive totalizer data")
         # firmware
         try:
             data["firmware"] = await self._client.firmware()

--- a/custom_components/delios/entity.py
+++ b/custom_components/delios/entity.py
@@ -12,7 +12,6 @@ from .client import (
     AlarmsData,
     StatusData,
     FirmwareData,
-    TotalizerData,
     SensorsData,
     ParametersData,
 )
@@ -53,6 +52,7 @@ class DeliosInverterAttribute:
     suggested_display_precision: Optional[int] = None
     value: Callable[[Any], Any] = lambda v: v
     attributes: dict[str, Callable[[Any], Any]] = {}
+    integration: bool = False
 
 
 class HelperFilterRangeType(Enum):
@@ -82,6 +82,70 @@ SENSORS: list[DeliosInverterAttribute] = [
         unit_of_measurement=UnitOfPower.WATT,
         value=lambda data: (
             float(data["sensors"].get("PowerBatt")) * 1000
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="battery_charge_power",
+        name="Battery Charge Power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit_of_measurement=UnitOfPower.WATT,
+        value=lambda data: (
+            max(0.0, -float(data["sensors"].get("PowerBatt")) * 1000)
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="battery_discharge_power",
+        name="Battery Discharge Power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit_of_measurement=UnitOfPower.WATT,
+        value=lambda data: (
+            max(0.0, float(data["sensors"].get("PowerBatt")) * 1000)
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="battery_charge_energy_total",
+        name="Battery Charge Energy Total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        integration=True,
+        value=lambda data: (
+            max(0.0, -float(data["sensors"].get("PowerBatt")) * 1000)
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="battery_discharge_energy_total",
+        name="Battery Discharge Energy Total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        integration=True,
+        value=lambda data: (
+            max(0.0, float(data["sensors"].get("PowerBatt")) * 1000)
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -127,6 +191,148 @@ SENSORS: list[DeliosInverterAttribute] = [
         unit_of_measurement=UnitOfPower.WATT,
         value=lambda data: (
             float(data["sensors"].get("PowerHouse")) * 1000
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    # Instantaneous power flows mirroring the energy totals (buyed / injected /
+    # self-consumed). The Delios API only exposes a single signed grid power
+    # (PowerGrid), so these split it by direction and derive self-consumption.
+    # Sign convention (verified on an IBRIDO DLS unit against live data):
+    #   PowerGrid > 0 = power drawn from the grid (buyed / import)
+    #   PowerGrid < 0 = power fed into the grid (injected / export)
+    # Self-consumed = the share of PV production not exported to the grid.
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="buyed_power",
+        name="Buyed Power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit_of_measurement=UnitOfPower.WATT,
+        value=lambda data: (
+            max(0.0, float(data["sensors"].get("PowerGrid")) * 1000)
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="injected_power",
+        name="Injected Power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit_of_measurement=UnitOfPower.WATT,
+        value=lambda data: (
+            max(0.0, -float(data["sensors"].get("PowerGrid")) * 1000)
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="self_consumed_power",
+        name="Self Consumed Power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        unit_of_measurement=UnitOfPower.WATT,
+        value=lambda data: (
+            max(
+                0.0,
+                (
+                    float(data["sensors"].get("PowerPV"))
+                    - max(0.0, -float(data["sensors"].get("PowerGrid")))
+                )
+                * 1000,
+            )
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    # Real-time energy totals, integrated from the instantaneous power flows above.
+    # These REPLACE the former TotalizerData-based *_energy_total sensors: the Delios
+    # /info/totalizer endpoint only commits its cumulative counters once per day at the
+    # inverter's local midnight, and the inverter clock stays on standard time (it does
+    # not follow DST). On the HA Energy dashboard a whole day's energy therefore landed
+    # in a single 01:00 bucket (00:00 in winter) and was attributed to the wrong day.
+    # Integrating the live power instead yields correctly time-bucketed, DST-correct
+    # energy. The running total is a RestoreSensor, so it persists across restarts.
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="photovoltaic_energy_total",
+        name="Photovoltaic Energy Total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        integration=True,
+        value=lambda data: (
+            float(data["sensors"].get("PowerPV")) * 1000
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="buyed_energy_total",
+        name="Buyed Energy Total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        integration=True,
+        value=lambda data: (
+            max(0.0, float(data["sensors"].get("PowerGrid")) * 1000)
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="injected_energy_total",
+        name="Injected Energy Total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        integration=True,
+        value=lambda data: (
+            max(0.0, -float(data["sensors"].get("PowerGrid")) * 1000)
+            if isinstance(data, dict)
+            and "sensors" in data
+            and isinstance(data["sensors"], SensorsData)
+            else None
+        ),
+    ),
+    DeliosInverterAttribute(
+        type=DeliosEntityType.SENSOR,
+        key="self_consumed_energy_total",
+        name="Self Consumed Energy Total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+        integration=True,
+        value=lambda data: (
+            max(
+                0.0,
+                (
+                    float(data["sensors"].get("PowerPV"))
+                    - max(0.0, -float(data["sensors"].get("PowerGrid")))
+                )
+                * 1000,
+            )
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -548,70 +754,6 @@ SETTINGS: list[DeliosEntityType] = [
             if isinstance(data, dict)
             and "firmware" in data
             and isinstance(data["firmware"], FirmwareData)
-            else None
-        ),
-    ),
-    DeliosInverterAttribute(
-        type=DeliosEntityType.SENSOR,
-        key="photovoltaic_energy_total",
-        name="Photovoltaic Energy Total",
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        suggested_display_precision=2,
-        value=lambda data: (
-            data["totalizer"].photovoltaic
-            if isinstance(data, dict)
-            and "totalizer" in data
-            and isinstance(data["totalizer"], TotalizerData)
-            else None
-        ),
-    ),
-    DeliosInverterAttribute(
-        type=DeliosEntityType.SENSOR,
-        key="buyed_energy_total",
-        name="Buyed Energy Total",
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        suggested_display_precision=2,
-        value=lambda data: (
-            data["totalizer"].buyed
-            if isinstance(data, dict)
-            and "totalizer" in data
-            and isinstance(data["totalizer"], TotalizerData)
-            else None
-        ),
-    ),
-    DeliosInverterAttribute(
-        type=DeliosEntityType.SENSOR,
-        key="injected_energy_total",
-        name="Injected Energy Total",
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        suggested_display_precision=2,
-        value=lambda data: (
-            data["totalizer"].injected
-            if isinstance(data, dict)
-            and "totalizer" in data
-            and isinstance(data["totalizer"], TotalizerData)
-            else None
-        ),
-    ),
-    DeliosInverterAttribute(
-        type=DeliosEntityType.SENSOR,
-        key="self_consumed_energy_total",
-        name="Self Consumed Energy Total",
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        device_class=SensorDeviceClass.ENERGY,
-        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        suggested_display_precision=2,
-        value=lambda data: (
-            data["totalizer"].self_consumed
-            if isinstance(data, dict)
-            and "totalizer" in data
-            and isinstance(data["totalizer"], TotalizerData)
             else None
         ),
     ),

--- a/custom_components/delios/entity.py
+++ b/custom_components/delios/entity.py
@@ -79,9 +79,10 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="Battery Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
-            float(data["sensors"].get("PowerBatt")) * 1000
+            float(data["sensors"].get("PowerBatt"))
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -94,9 +95,10 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="Battery Charge Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
-            max(0.0, -float(data["sensors"].get("PowerBatt")) * 1000)
+            max(0.0, -float(data["sensors"].get("PowerBatt")))
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -109,9 +111,10 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="Battery Discharge Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
-            max(0.0, float(data["sensors"].get("PowerBatt")) * 1000)
+            max(0.0, float(data["sensors"].get("PowerBatt")))
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -158,9 +161,10 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="Grid Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
-            float(data["sensors"].get("PowerGrid")) * 1000
+            float(data["sensors"].get("PowerGrid"))
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -173,9 +177,10 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="Photovoltaic Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
-            float(data["sensors"].get("PowerPV")) * 1000
+            float(data["sensors"].get("PowerPV"))
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -188,9 +193,10 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="House Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
-            float(data["sensors"].get("PowerHouse")) * 1000
+            float(data["sensors"].get("PowerHouse"))
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -210,9 +216,10 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="Buyed Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
-            max(0.0, float(data["sensors"].get("PowerGrid")) * 1000)
+            max(0.0, float(data["sensors"].get("PowerGrid")))
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -225,9 +232,10 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="Injected Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
-            max(0.0, -float(data["sensors"].get("PowerGrid")) * 1000)
+            max(0.0, -float(data["sensors"].get("PowerGrid")))
             if isinstance(data, dict)
             and "sensors" in data
             and isinstance(data["sensors"], SensorsData)
@@ -240,15 +248,13 @@ SENSORS: list[DeliosInverterAttribute] = [
         name="Self Consumed Power",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        unit_of_measurement=UnitOfPower.WATT,
+        unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=2,
         value=lambda data: (
             max(
                 0.0,
-                (
-                    float(data["sensors"].get("PowerPV"))
-                    - max(0.0, -float(data["sensors"].get("PowerGrid")))
-                )
-                * 1000,
+                float(data["sensors"].get("PowerPV"))
+                - max(0.0, -float(data["sensors"].get("PowerGrid"))),
             )
             if isinstance(data, dict)
             and "sensors" in data

--- a/custom_components/delios/manifest.json
+++ b/custom_components/delios/manifest.json
@@ -11,5 +11,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/lnx85/delios/issues",
     "requirements": [],
-    "version": "1.2.0"
+    "version": "2.0.0"
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,47 @@
+"""Tests for the Delios client data parsing."""
+
+import pytest
+
+from custom_components.delios.client import (
+    InvalidAttribute,
+    ParametersData,
+    SensorsData,
+)
+
+
+def test_sensors_data_parses_variable_list():
+    """A normal dashboard payload is parsed into ctrl_name -> value."""
+    data = SensorsData(
+        {"variables": [{"ctrl_name": "VL1", "value": "251.5"}]}
+    )
+    assert data.get("VL1") == 251.5
+
+
+def test_sensors_data_null_variables_does_not_crash():
+    """A payload with `variables: null` must not raise (regression).
+
+    Some inverters / firmware return {"variables": null} for an endpoint;
+    iterating over None previously raised TypeError and broke the whole
+    coordinator update.
+    """
+    data = SensorsData({"variables": None})
+    with pytest.raises(InvalidAttribute):
+        data.get("VL1")
+
+
+def test_parameters_data_null_variables_does_not_crash():
+    """`info/system` returns {"variables": null} on some hardware (regression).
+
+    The parameters endpoint can legitimately have no variables; parsing it
+    must yield an empty, queryable object instead of raising TypeError.
+    """
+    params = ParametersData({"variables": None})
+    with pytest.raises(InvalidAttribute):
+        params.get("ACinvTemp")
+
+
+def test_parameters_data_missing_key_returns_invalid_attribute():
+    """Reading an absent ctrl_name raises InvalidAttribute, not KeyError."""
+    params = ParametersData({"variables": []})
+    with pytest.raises(InvalidAttribute):
+        params.get("ACinvTemp")


### PR DESCRIPTION
Add Energy-dashboard support for Delios inverters:

- New DeliosIntegrationSensor: integrates instantaneous power (W) over time (trapezoidal rule) into cumulative energy (kWh) and restores its total across restarts (RestoreSensor); driven by an `integration` flag on DeliosInverterAttribute.
- Battery charge/discharge power and energy-total sensors.
- Per-flow instantaneous power sensors: buyed/injected (grid import/export split from the signed PowerGrid) and self_consumed.
- Replace the /info/totalizer-based *_energy_total sensors with real-time integrated ones: the inverter commits the totalizer once a day at its local midnight and ignores DST, so a whole day's energy landed in a single ~01:00 bucket on the wrong day with no intraday distribution.
- Remove the now-unused totalizer plumbing (DeliosClient.totalizer(), TotalizerData, the coordinator fetch).
- Handle inverter endpoints that return no variables; ignore the dist dir.

BREAKING CHANGE: the four *_energy_total entities keep their ids but change meaning (inverter lifetime totalizer -> integrated-from-zero) and reset to ~0 on upgrade (handled by HA as a meter reset); bumped to 2.0.0.

---

**Follow-up — power sensors now report kW:** the instantaneous `*_power` sensors (`battery`/`battery_charge`/`battery_discharge`/`grid`/`photovoltaic`/`house`/`buyed`/`injected`/`self_consumed`) now report **kW** natively instead of W. The Delios dashboard API already returns these in kW, so the previous `*1000` was dropped, the unit switched to `UnitOfPower.KILO_WATT`, and `suggested_display_precision=2` added. The `*_energy_total` integration sensors are unaffected — they still integrate the watt-scaled power internally (W·s → kWh). README unit labels updated.
